### PR TITLE
[Chore] UI 개선 - 레전더리 아이템 섹션 배경 추가, 보유 메소 이미지 추가

### DIFF
--- a/GaCha/View/GachaCollectionView.swift
+++ b/GaCha/View/GachaCollectionView.swift
@@ -48,11 +48,11 @@ extension GachaCollectionView {
         configuration.interSectionSpacing = 10
         backgroundColor = .white
         
-        return UICollectionViewCompositionalLayout(sectionProvider: { [unowned self] section, environment in
+        let layout = UICollectionViewCompositionalLayout(sectionProvider: { [unowned self] section, environment in
             // Header 설정
             let headerItem = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: NSCollectionLayoutSize(
                   widthDimension: .fractionalWidth(1),
-                  heightDimension: .absolute(30)
+                  heightDimension: .absolute(32)
               ),
                   elementKind: "HeaderKind",
                   alignment: .top
@@ -87,6 +87,9 @@ extension GachaCollectionView {
             default: return nil
             }
         }, configuration: configuration)
+        
+        layout.register(CollectionBackgroundView.self, forDecorationViewOfKind: "legendaryBackground")
+        return layout
     }
 }
 
@@ -95,55 +98,58 @@ extension GachaCollectionView {
     // 레전더리 아이템 목록 섹션 레이아웃
     private func setLegendaryListSection(_ environment: any NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection {
         // 기본 설정
-          let spacing: CGFloat = 8
-          
-          // CollectionView 사이즈 - effectiveContentSize는 인셋 빼고 계산, 그냥 contentSize는 인셋 포함하여 계산
-          let containerSize = environment.container.effectiveContentSize
-          
+        let spacing: CGFloat = 8
+        
+        // CollectionView 사이즈 - effectiveContentSize는 인셋 빼고 계산, 그냥 contentSize는 인셋 포함하여 계산
+        let containerSize = environment.container.effectiveContentSize
+        
         // Item 설정
-          let itemSize = (containerSize.width) / 2 // 아이템 1개 가로 사이즈
-          let item = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(
-              widthDimension: .absolute(itemSize),
-              heightDimension: .fractionalHeight(1)
-          ))
-          
+        let itemSize = (containerSize.width) / 2 // 아이템 1개 가로 사이즈
+        let item = NSCollectionLayoutItem(layoutSize: NSCollectionLayoutSize(
+            widthDimension: .absolute(itemSize),
+            heightDimension: .fractionalHeight(1)
+        ))
+        
         // Group 설정
-          // 내부 그룹(아이템 2개 표시 횡렬 그룹) 설정
-          let inLineGroup1 = NSCollectionLayoutGroup.horizontal(layoutSize: NSCollectionLayoutSize(
-              widthDimension: .fractionalWidth(1),
-              heightDimension: .absolute(itemSize * 0.7)
-              ),
-              repeatingSubitem: item,
-              count: 2
-          )
-          
-          let inLineGroup2 = NSCollectionLayoutGroup.horizontal(layoutSize: NSCollectionLayoutSize(
-              widthDimension: .fractionalWidth(1),
-              heightDimension: .absolute(itemSize * 0.7)
-              ),
-              repeatingSubitem: item,
-              count: 2
-          )
-          
-          // 전체 그룹 설정
-          let entireGroup = NSCollectionLayoutGroup.vertical(layoutSize: NSCollectionLayoutSize(
-              widthDimension: .fractionalWidth(1),
-              heightDimension: .absolute(itemSize * 1.4)
-          ),
-              subitems: [inLineGroup1, inLineGroup2]
-          )
-          
+        // 내부 그룹(아이템 2개 표시 횡렬 그룹) 설정
+        let inLineGroup1 = NSCollectionLayoutGroup.horizontal(layoutSize: NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .absolute(itemSize * 0.7)
+        ),
+                                                              repeatingSubitem: item,
+                                                              count: 2
+        )
+        
+        let inLineGroup2 = NSCollectionLayoutGroup.horizontal(layoutSize: NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .absolute(itemSize * 0.7)
+        ),
+                                                              repeatingSubitem: item,
+                                                              count: 2
+        )
+        
+        // 전체 그룹 설정
+        let entireGroup = NSCollectionLayoutGroup.vertical(layoutSize: NSCollectionLayoutSize(
+            widthDimension: .fractionalWidth(1),
+            heightDimension: .absolute(itemSize * 1.4)
+        ),
+                                                           subitems: [inLineGroup1, inLineGroup2]
+        )
+        
         // Section 설정
-          let section = NSCollectionLayoutSection(group: entireGroup)
-          section.interGroupSpacing = spacing * 3 // 그룹 간 공백 설정
-          section.orthogonalScrollingBehavior = .groupPaging // 그룹 간 스크롤 설정 - 페이징 형식
-          
-          section.visibleItemsInvalidationHandler = { [weak self] _, contentOffset, environment in
-              let currentPage = Int(max(0, contentOffset.x / containerSize.width)) // 현재 페이지 = 현재 스크롤 위치(x) / 컬렉션뷰 가로 길이
-              self?.pageControl?.currentPage = currentPage // 현재 페이지 변경
-          }
-          
-          return section
+        let section = NSCollectionLayoutSection(group: entireGroup)
+        section.interGroupSpacing = spacing * 3 // 그룹 간 공백 설정
+        section.orthogonalScrollingBehavior = .groupPaging // 그룹 간 스크롤 설정 - 페이징 형식
+        
+        section.visibleItemsInvalidationHandler = { [weak self] _, contentOffset, environment in
+            let currentPage = Int(max(0, contentOffset.x / containerSize.width)) // 현재 페이지 = 현재 스크롤 위치(x) / 컬렉션뷰 가로 길이
+            self?.pageControl?.currentPage = currentPage // 현재 페이지 변경
+        }
+        
+        // Background 설정
+        let sectionBackground = NSCollectionLayoutDecorationItem.background(elementKind: "legendaryBackground")
+        section.decorationItems = [sectionBackground]
+        return section
     }
     
     // 버튼 섹션 레이아웃

--- a/GaCha/View/GachaViewComp/CollectionBackgroundView.swift
+++ b/GaCha/View/GachaViewComp/CollectionBackgroundView.swift
@@ -1,0 +1,34 @@
+//
+//  CollectionBackgroundView.swift
+//  GaCha
+//
+//  Created by t2025-m0143 on 2/8/26.
+//
+
+import UIKit
+import SnapKit
+
+final class CollectionBackgroundView: UICollectionReusableView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        let view = UIView()
+        
+        view.backgroundColor = .apricot
+        view.layer.cornerRadius = 16
+        view.clipsToBounds = true
+        view.layer.borderColor = UIColor.mushroomOrange.cgColor
+        view.layer.borderWidth = 0.2
+        
+        addSubview(view)
+        
+        view.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(32)
+            $0.bottom.equalToSuperview().offset(-28)
+            $0.horizontalEdges.equalToSuperview().inset(-15)
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/GaCha/View/GachaViewComp/GachaResultCell.swift
+++ b/GaCha/View/GachaViewComp/GachaResultCell.swift
@@ -79,9 +79,11 @@ extension GachaResultCell {
         if gradeLabel.text == "레전더리" {
             contentView.backgroundColor = .mushroomOrange
             nameLabel.textColor = .white
+            gradeLabel.textColor = .white
         } else {
             contentView.backgroundColor = .apricot
             nameLabel.textColor = .black
+            gradeLabel.textColor = .black
         }
     }
 }

--- a/GaCha/View/MainView.swift
+++ b/GaCha/View/MainView.swift
@@ -38,7 +38,6 @@ class MainView: UIView {
         addSubview(purchaseButton)
         addSubview(gachaCollectionView)
         
-        
         titleLabel.snp.makeConstraints {
             $0.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
             $0.top.equalTo(safeAreaLayoutGuide).offset(10)

--- a/GaCha/View/MesoStackView.swift
+++ b/GaCha/View/MesoStackView.swift
@@ -14,21 +14,24 @@ class MesoStackView: UIStackView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
+        let space = UILabel()
+        space.text = " "
+        
         // 타이틀 레이블 생성
         let title = makeCurrentMesoTitleLabel()
-        
-        // 타이틀 레이블 설정
-        title.textAlignment = .right // 텍스트 오른쪽정렬
+        let image = makeMesoImageView()
         
         setAttributes()
-        
         updateMeso()
         
+        addArrangedSubview(space)
+        addArrangedSubview(image)
         addArrangedSubview(title)
         addArrangedSubview(currentMesoLabel)
         
         axis = .horizontal
         spacing = 8
+
     }
     
     required init(coder: NSCoder) {
@@ -56,6 +59,7 @@ extension MesoStackView {
         label.text = "보유 메소"
         label.textColor = .black
         label.font = .boldSystemFont(ofSize: 16)
+        label.textAlignment = .right
         
         return label
     }
@@ -65,5 +69,16 @@ extension MesoStackView {
         currentMesoLabel.textColor = .black
         currentMesoLabel.font = .systemFont(ofSize: 16)
         currentMesoLabel.setContentHuggingPriority(.required, for: .horizontal) // 우선순위 설정
+    }
+    
+    // 보유 메소 타이틀 스택 생성
+    private func makeMesoImageView() -> UIImageView {
+        let image = UIImageView(image: .meso)
+        
+        image.snp.makeConstraints {
+            $0.width.equalTo(image.snp.height)
+        }
+        
+        return image
     }
 }

--- a/GaCha/View/MesoStackView.swift
+++ b/GaCha/View/MesoStackView.swift
@@ -71,7 +71,7 @@ extension MesoStackView {
         currentMesoLabel.setContentHuggingPriority(.required, for: .horizontal) // 우선순위 설정
     }
     
-    // 보유 메소 타이틀 스택 생성
+    // 보유 메소 이미지 생성
     private func makeMesoImageView() -> UIImageView {
         let image = UIImageView(image: .meso)
         

--- a/GaCha/View/MesoStackView.swift
+++ b/GaCha/View/MesoStackView.swift
@@ -10,32 +10,36 @@ import SnapKit
 class MesoStackView: UIStackView {
     // 현재 보유 메소 레이블
     private let currentMesoLabel = UILabel()
+    private let mesoImageView = UIImageView(image: .meso)
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         
         let space = UILabel()
         space.text = " "
+        space.setContentCompressionResistancePriority(.required, for: .horizontal)
         
-        // 타이틀 레이블 생성
-        let title = makeCurrentMesoTitleLabel()
-        let image = makeMesoImageView()
+        let titleStack = setTitleStackView()
         
         setAttributes()
         updateMeso()
         
         addArrangedSubview(space)
-        addArrangedSubview(image)
-        addArrangedSubview(title)
+        addArrangedSubview(titleStack)
         addArrangedSubview(currentMesoLabel)
         
         axis = .horizontal
         spacing = 8
-
     }
     
     required init(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // 메소 이미지 크기 조정 - 원본 크기의 70%
+        mesoImageView.transform = CGAffineTransform(scaleX: 0.7, y: 0.7)
     }
 }
 
@@ -72,13 +76,19 @@ extension MesoStackView {
     }
     
     // 보유 메소 이미지 생성
-    private func makeMesoImageView() -> UIImageView {
-        let image = UIImageView(image: .meso)
+    private func setTitleStackView() -> UIStackView {
+        // 타이틀 레이블 생성
+        let title = makeCurrentMesoTitleLabel()
+        let stackView = UIStackView(arrangedSubviews: [mesoImageView, title])
         
-        image.snp.makeConstraints {
-            $0.width.equalTo(image.snp.height)
+        stackView.axis = .horizontal
+        stackView.spacing = 0
+        
+        title.setContentHuggingPriority(.required, for: .horizontal)
+        
+        mesoImageView.snp.makeConstraints {
+            $0.width.equalTo(mesoImageView.snp.height)
         }
-        
-        return image
+        return stackView
     }
 }


### PR DESCRIPTION
## 🛠 작업 내용 (What I did)
- 레전더리 아이템 섹션 배경 색상 추가
- 보유 메소 이미지 추가

## 💻 구현 상세 (Implementation Details)
- 레전더리 아이템 섹션에 배경 색상을 추가하였습니다.
- 보유 메소 타이틀 레이블 왼쪽에 메소 이미지를 추가하였습니다.
    -> 이미지가 좀 커서 별로 어울리지 않는듯한 느낌이 있습니다..
## 📸 스크린샷 (Screenshots)
<p align=center><img src="https://github.com/user-attachments/assets/9962885b-f2a8-47c4-9518-fbb5da296aae" width=50%></p>

## 🧐 리뷰 포인트 (Review Points)
- 메소 이미지 추가 여부 및 배경 색상 검토 부탁드립니다.

## ✅ 자가 점검 (Self Checklist)
- [ ] 빌드 및 테스트가 정상적으로 통과되었나요?
- [ ] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [ ] 불필요한 주석이나 디버그 코드를 삭제했나요?
