### PR TITLE
♻️ refactor: ItemTableView 셀 크기 50 고정, 표시 셀 개수 12개 고정, 셀 색상 지정

### DIFF
--- a/GaCha/Controller/InventoryViewController.swift
+++ b/GaCha/Controller/InventoryViewController.swift
@@ -66,6 +66,12 @@ extension InventoryViewController: UITableViewDelegate {
 
 extension InventoryViewController: InventoryViewDelegate {
     func didTapSellAllButton() {
+        
+        if DataManager.shared.inventoryList.isEmpty {
+            showErrorAlert(message: "판매할 아이템이 없습니다.")
+            return
+        }
+        
         let alert = UIAlertController(title: "전체 판매", message: "아이템을 전부 판매하시겠습니까?", preferredStyle: .alert)
         let cancel = UIAlertAction(title: "취소하기", style: .cancel)
         let confirm = UIAlertAction(title: "판매하기", style: .destructive) { [weak self] _ in

--- a/GaCha/Controller/ViewController.swift
+++ b/GaCha/Controller/ViewController.swift
@@ -72,6 +72,7 @@ extension ViewController {
             mainView.purchaseButton.isHidden = false
             self.itemList = ItemData.allItems.filter {
                 $0.category == selectedCategory && $0.grade == "일반" }
+            mainView.itemTableView.setContentOffset(.zero, animated: false)
         }
     }
     
@@ -107,7 +108,9 @@ extension ViewController: UITableViewDataSource {
 }
 
 extension ViewController: UITableViewDelegate {
-    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 50
+    }
 }
 
 // GachaView CollectionView datasource 정의
@@ -265,7 +268,7 @@ extension ViewController {
 extension ViewController {
     func gacha() {
         let items = ItemData.allItems.filter { $0.grade == "일반" }
-        let num = Int.random(in: 1...1000) // 1/1000 확률
+        let num = Int.random(in: 1...10) // 1/1000 확률
         
         // num이 1일 때: itemList(레전더리 아이템 목록)에서 결과 추출
         // num이 1이 아닐 때: items(일반 아이템)에서 결과 추출

--- a/GaCha/Controller/ViewController.swift
+++ b/GaCha/Controller/ViewController.swift
@@ -268,7 +268,7 @@ extension ViewController {
 extension ViewController {
     func gacha() {
         let items = ItemData.allItems.filter { $0.grade == "일반" }
-        let num = Int.random(in: 1...10) // 1/1000 확률
+        let num = Int.random(in: 1...1000) // 1/1000 확률
         
         // num이 1일 때: itemList(레전더리 아이템 목록)에서 결과 추출
         // num이 1이 아닐 때: items(일반 아이템)에서 결과 추출

--- a/GaCha/Controller/ViewController.swift
+++ b/GaCha/Controller/ViewController.swift
@@ -227,7 +227,7 @@ extension ViewController: UICollectionViewDelegate {
 extension ViewController: MainViewDelegate {
     func didTapPurchaseButton() {
         guard let selectedPaths = mainView.itemTableView.indexPathsForSelectedRows else {
-            print("선택된 아이템이 없습니다.") //TODO: 선택된 아이템없을 시 버튼 비활성화
+            showErrorAlert(message: "선택된 아이템이 없습니다.")
             return
         }
         

--- a/GaCha/View/InventoryViewComp/InventoryItemCell.swift
+++ b/GaCha/View/InventoryViewComp/InventoryItemCell.swift
@@ -62,6 +62,9 @@ extension InventoryItemCell {
         stackView.alignment = .center
         stackView.spacing = 5
         
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.layoutMargins = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 5)
+        
     }
     
     private func setLayout() {
@@ -101,6 +104,22 @@ extension InventoryItemCell {
         
         let formatter = FormatterManager()
         itemPriceLabel.text = formatter.setMesoToString(meso: purchaseItem.totalPrice)
+        
+        if purchaseItem.item.grade == "레전더리" {
+            contentView.backgroundColor = .mushroomOrange
+            itemNameLabel.textColor = .white
+            itemCountLabel.textColor = .white
+            itemPriceLabel.textColor = .white
+            sellButton.backgroundColor = .apricot
+            sellButton.setTitleColor(.mushroomOrange, for: .normal)
+        } else {
+            contentView.backgroundColor = .apricot
+            itemNameLabel.textColor = .black
+            itemCountLabel.textColor = .darkGray
+            itemPriceLabel.textColor = .darkGray
+            sellButton.backgroundColor = .mushroomOrange
+            sellButton.setTitleColor(.white, for: .normal)
+        }
     }
 }
 

--- a/GaCha/View/ItemViewComp/ItemCell.swift
+++ b/GaCha/View/ItemViewComp/ItemCell.swift
@@ -35,6 +35,8 @@ extension ItemCell {
         
         itemPriceLabel.font = .systemFont(ofSize: 14)
         itemPriceLabel.textColor = .darkGray
+        
+        contentView.backgroundColor = .apricot
     }
     
     private func setLayout() {

--- a/GaCha/View/ItemViewComp/ItemCell.swift
+++ b/GaCha/View/ItemViewComp/ItemCell.swift
@@ -36,7 +36,7 @@ extension ItemCell {
         itemPriceLabel.font = .systemFont(ofSize: 14)
         itemPriceLabel.textColor = .darkGray
         
-        contentView.backgroundColor = .apricot
+//        contentView.backgroundColor = .apricot
     }
     
     private func setLayout() {

--- a/GaCha/View/MainView.swift
+++ b/GaCha/View/MainView.swift
@@ -10,6 +10,9 @@ import SnapKit
 
 class MainView: UIView {
     
+    let cellHeight: CGFloat = 50
+    let rowsCount: CGFloat = 12
+    
     weak var delegate: MainViewDelegate?
     
     let mesoStack = MesoStackView()
@@ -65,11 +68,11 @@ class MainView: UIView {
         itemTableView.snp.makeConstraints {
             $0.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
             $0.top.equalTo(categorySegment.snp.bottom).offset(10)
-            $0.bottom.equalTo(purchaseButton.snp.top).offset(-20)
+            $0.height.equalTo(cellHeight * rowsCount)
         }
         
         purchaseButton.snp.makeConstraints {
-            $0.bottom.equalTo(safeAreaLayoutGuide)
+            $0.top.equalTo(itemTableView.snp.bottom).offset(10)
             $0.trailing.equalTo(safeAreaLayoutGuide).offset(-20)
             $0.width.equalTo(100)
         }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,100 @@
-가챠뽑기
+# 🎰GaCha!
+**GaCha**는 메이플스토리의 클래식한 디자인과 경제 시스템을 모티브로 한 아이템 상점 및 확률형 뽑기 시뮬레이션 iOS 앱입니다.
+
+## 🧾 프로젝트 소개
+**GaCha!** 프로젝트는 **iOS UIKit** 기반으로 메이플스토리 감성의 아이템 샵과 뽑기 시스템을 설계·구현하며고급 레이아웃 구성, 효율적인 데이터 구조, 객체 간 통신을 학습하기 위해 제작된 프로젝트입니다.
+- **IdentifiedCollections 기반 통합 데이터 관리**: 인벤토리 내 중복 아이템 합산 및 수정 시 `$O(1)$` 성능 확보
+- **Compositional Layout 중심 UI 구성**: 단일 `CollectionView` 내 멀티 섹션(Paging, Button, List) 구현
+- **Protocol-Oriented Communication**: 다양한 `Delegate` 패턴 적용으로 객체 간 결합도 최소화
+- **SnapKit 기반의 정교한 UI 설계**: 레이아웃 및 등급별 동적 테마 적용
+
+## ✨ 핵심 기능 (Key Features)
+- **1. 하이브리드 상점 시스템**
+    - **멀티 카테고리 지원**: 무기, 상의, 하의, 모자, 신발 등 5가지 카테고리의 아이템 데이터를 분류하여 제공합니다.
+    - **일반 아이템 구매**: 상점 리스트에서 일반 등급 아이템을 다중 선택하여 보유한 '메소'로 즉시 구매할 수 있습니다.
+
+- **2. 고도화된 가챠(뽑기) 시스템**
+    - **확률형 아이템 획득**: **지정된 확률** 로 강력한 레전더리 아이템을 획득할 수 있는 뽑기 로직을 구현했습니다.
+    - **연속 뽑기 기능**: 1회 및 5회 연속 뽑기 기능을 지원하며, 결과는 즉시 인벤토리에 반영됩니다.
+    - **실시간 결과 트래킹**: 가챠 결과 섹션을 통해 최근 획득한 아이템 5개를 실시간으로 확인할 수 있습니다.
+
+- **3. 스마트 인벤토리 및 경제 시스템**
+    - **자동 스택 관리**: 동일 아이템 획득 시 인벤토리 내 수량이 자동으로 합산되어 효율적인 관리가 가능합니다.
+    - **아이템 판매 및 환급**: 보유 아이템을 개별 혹은 전체 판매할 수 있으며, 판매 시 원가에 **지정된 감가**를 적용하여 메소로 환급받습니다.
+    - **실시간 재화 동기화**: `DataManager`의 재화 상태 변화를 감지하여 메인 화면의 메소 잔액 UI를 즉각적으로 갱신합니다.
+
+- **4. 등급별 동적 테마 UI**
+    - **시각적 희귀도 강조**: 아이템 등급(일반, 레전더리)에 따라 셀의 배경색과 텍스트 컬러가 자동으로 반전되어 획득의 재미를 시각화했습니다.
+    - **정밀한 레이아웃**: `SnapKit`을 활용해 테이블 뷰와 헤더 간의 컬럼 너비를 정밀하게 일치시켜 가독성 높은 정보를 제공합니다.
+
+## 📁 프로젝트 구조
+```
+GaCha 
+├── Controller 
+│   ├── InventoryViewController.swift 
+│   └── ViewController.swift 
+├── Helper 
+│   ├── FormatterManager.swift 
+│   ├── GachaCategory.swift 
+│   └── Identifier.swift 
+├── Model 
+│   ├── DataManager.swift 
+│   ├── Item.swift 
+│   ├── Meso.swift 
+│   └── PurchaseItem.swift 
+├── Protocol 
+│   ├── CategorySegmentedControlDelegate.swift 
+│   ├── InventoryItemCellDelegate.swift 
+│   ├── InventoryViewControllerDelegate.swift 
+│   ├── InventoryViewDelegate.swift 
+│   └── MainViewDelegate.swift 
+├── View 
+│   ├── GachaViewComp 
+│   │   ├── GachaButtonCell.swift 
+│   │   ├── GachaCollectionFooterView.swift 
+│   │   ├── GachaCollectionHeaderView.swift 
+│   │   ├── GachaResultCell.swift 
+│   │   ├── LegendaryItemCell.swift 
+│   │   └── MesoBadgeView.swift 
+│   ├── InventoryViewComp 
+│   │   ├── InventoryHeaderView.swift 
+│   │   ├── InventoryItemCell.swift 
+│   │   ├── InventoryTableView.swift 
+│   │   └── InventoryView.swift 
+│   ├── ItemViewComp 
+│   │   ├── ItemCell.swift 
+│   │   └── ItemTableView.swift 
+│   ├── ActionButton.swift 
+│   ├── CategorySegmentedControl.swift 
+│   ├── GachaCollectionView.swift 
+│   ├── MainView.swift 
+│   └── MesoStackView.swift 
+└── Resources 
+    ├── AppDelegate.swift 
+    ├── SceneDelegate.swift 
+    ├── Assets.xcassets 
+    └── Info.plist
+```
+
+## 📁 구조 설명
+### Controller
+- **ViewController.swift**: `종합 시스템 관리`
+- **InventoryViewController.swift**: `Inventory Modal 시스템 관리`
+
+### Model
+- **DataManager.swift**: `Singleton Pattern`, `Meso`, `inventoryList` 통합 관리
+
+### View
+- **GachaViewComp**
+    - **...Cell**: 각 `Section`에 필요한 `Custom Cell` 정의
+    - **...View**: `Section` 주변의 부가적인 View (`Header`, `Footer`, `Badge`)
+- **InventoryViewComp, ItemViewComp**
+    - **...Cell**: 각 TableView의 `Custom Cell`
+    - **...View**: `UI` 정의
+- **MainView(디렉토리에 포함되지 않은 파일)**: MainView 내부 `UI` 정의
+
+## 🛠 Tech Stack
+- **Language**: `Swift`
+- **UI Framework**: `UIKit`
+- **Layout**: `SnapKit`
+- **Design Pattern**: `MVC, Delegate, Singleton`


### PR DESCRIPTION
## 🎫 관련 이슈 (Linked Issues)
Closes #

## 🛠 작업 내용 (What I did)
- 셀 크기 50 고정
- 테이블 뷰 표시 셀 개수 12개 고정
- 셀 내부 색상 mushroomOrange
- InventoryTableView 표시 아이템 색상 조정
- InventoryItemCell 마진 추가(left: 5)

## 💻 구현 상세 (Implementation Details),📸 스크린샷 (Screenshots)
<img width="300" height="600" alt="스크린샷 2026-02-08 오후 10 22 34" src="https://github.com/user-attachments/assets/4bafd0f6-af71-46fd-9b9e-31934ae62383" />
<img width="300" height="600" alt="스크린샷 2026-02-08 오후 10 23 20" src="https://github.com/user-attachments/assets/43d0488a-a50f-49b9-82ef-11a2d7d68d1c" />

## 🧐 리뷰 포인트 (Review Points)
- `ImagePicker`의 메모리 해제 처리가 올바르게 되었는지 확인 부탁드립니다.
- 권한 거부 시 노출되는 알림 팝업 문구가 적절한지 봐주세요.

## ✅ 자가 점검 (Self Checklist)
- [ ] 빌드 및 테스트가 정상적으로 통과되었나요?
- [ ] 관련 이슈 번호를 정확히 기재했나요? (Closes #...)
- [ ] 불필요한 주석이나 디버그 코드를 삭제했나요?
